### PR TITLE
Add simple UI served from API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Build and run all services:
 ```bash
 docker compose up --build
 ```
+
+The UI will be available at [http://localhost:8000/ui](http://localhost:8000/ui) once all services start.

--- a/api_gateway/app/main.py
+++ b/api_gateway/app/main.py
@@ -1,10 +1,38 @@
 from fastapi import FastAPI, WebSocket
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+import httpx
 
 app = FastAPI(title="API Gateway")
+
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 @app.get("/")
 async def read_root():
     return {"message": "api_gateway"}
+
+@app.get("/ui")
+async def ui():
+    return FileResponse("app/static/index.html")
+
+@app.get("/services")
+async def service_status():
+    services = {
+        "indicator_engine": "http://indicator_engine:8000",
+        "strategy_engine": "http://strategy_engine:8000",
+        "trade_executor": "http://trade_executor:8000",
+        "market_data": "http://market_data:8000",
+        "backtester": "http://backtester:8000",
+    }
+    results = {}
+    async with httpx.AsyncClient() as client:
+        for name, url in services.items():
+            try:
+                r = await client.get(url)
+                results[name] = r.json().get("message")
+            except Exception:
+                results[name] = "unavailable"
+    return results
 
 @app.websocket("/ws")
 async def websocket_endpoint(ws: WebSocket):

--- a/api_gateway/app/static/index.html
+++ b/api_gateway/app/static/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Robot UI</title>
+</head>
+<body>
+    <h1>Robot Services</h1>
+    <ul id="services">Loading...</ul>
+    <script>
+        fetch('/services')
+            .then(r => r.json())
+            .then(data => {
+                const ul = document.getElementById('services');
+                ul.innerHTML = '';
+                Object.entries(data).forEach(([name, message]) => {
+                    const li = document.createElement('li');
+                    li.textContent = name + ': ' + message;
+                    ul.appendChild(li);
+                });
+            })
+            .catch(() => {
+                document.getElementById('services').textContent = 'Failed to load';
+            });
+    </script>
+</body>
+</html>

--- a/api_gateway/requirements.txt
+++ b/api_gateway/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+httpx
+aiofiles


### PR DESCRIPTION
## Summary
- add a basic HTML interface in `api_gateway`
- expose `/ui` and `/services` endpoints
- query all services from the gateway using `httpx`
- document the UI in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6852a724d274832bab9102aa65c1a6b1