### PR TITLE
Fix UI path handling

### DIFF
--- a/api_gateway/app/main.py
+++ b/api_gateway/app/main.py
@@ -1,11 +1,14 @@
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 import httpx
 
 app = FastAPI(title="API Gateway")
 
-app.mount("/static", StaticFiles(directory="app/static"), name="static")
+BASE_DIR = Path(__file__).resolve().parent
+
+app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 
 @app.get("/")
 async def read_root():
@@ -13,7 +16,7 @@ async def read_root():
 
 @app.get("/ui")
 async def ui():
-    return FileResponse("app/static/index.html")
+    return FileResponse(BASE_DIR / "static" / "index.html")
 
 @app.get("/services")
 async def service_status():

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -7,3 +7,9 @@ def test_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "api_gateway"}
+
+
+def test_ui():
+    response = client.get("/ui")
+    assert response.status_code == 200
+    assert b"Robot Services" in response.content


### PR DESCRIPTION
## Summary
- reference static UI files using an absolute path
- add a test for the UI endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6852a8d760b0832ba33ce73ecab01f51