### PR TITLE
Expand trading robot mock services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 # Robot Platform
 
-This repository contains a minimal skeleton for the trading platform described in the technical specification. Each service is implemented as a small FastAPI application.
+This repository implements a small example of the trading robot described in the technical specification. Each component is a FastAPI microservice and all services can be started with Docker Compose.
 
 ## Services
-
-- `api-gateway`
-- `indicator-engine`
-- `strategy-engine`
-- `trade-executor`
-- `market-data`
-- `backtester`
+- **api-gateway** – exposes the UI and provides a central entry point to other services
+- **indicator-engine** – calculates trading indicators (e.g. moving average)
+- **strategy-engine** – stores simple strategies composed of weighted indicators
+- **trade-executor** – mock order execution with an on/off toggle
+- **market-data** – provides mocked market data using a Bybit connector
+- **backtester** – runs a very basic backtest using market data
 
 ## Running with Docker Compose
-
-Build and run all services:
 
 ```bash
 docker compose up --build
 ```
 
-The UI will be available at [http://localhost:8000/ui](http://localhost:8000/ui) once all services start.
+After startup open [http://localhost:8000/ui](http://localhost:8000/ui) to access the web UI.

--- a/TRADING_ROBOT_PROMPT.md
+++ b/TRADING_ROBOT_PROMPT.md
@@ -1,0 +1,24 @@
+# Trading Robot Design
+
+This document describes a simple microservice based trading robot. It is written to be used as a prompt for Codex or as guidance when extending the project.
+
+## Overview
+The platform is split into separate services which communicate over HTTP. Every service is a FastAPI application. All services are started with the provided `docker-compose.yml` file.
+
+### Services
+1. **api-gateway** – serves the web UI and proxies requests to the internal services.
+2. **indicator-engine** – calculates indicators such as moving averages.
+3. **strategy-engine** – stores strategies which are defined as a list of indicators and their weights.
+4. **trade-executor** – places orders. The execution can be globally enabled or disabled via the `/toggle` endpoint.
+5. **market-data** – connects to Bybit (mocked) and provides candle data.
+6. **backtester** – runs simplified backtests using data from `market-data`.
+
+## Features
+- Web UI available at `/ui` to view service status, fetch market data and enable/disable trading.
+- Toggle external activity (placing orders) via `POST /toggle` on the `trade-executor` service.
+- Calculate indicators through `indicator-engine` (currently only moving average is implemented).
+- Create and fetch strategies with `strategy-engine`.
+- Retrieve mocked candles from `market-data`.
+- Run a minimal backtest using `backtester`.
+
+This repository only contains minimal logic meant for demonstration and testing. The mocked Bybit connector located in `market_data/app/bybit_connector.py` can be replaced with a real implementation if API keys and network access are provided.

--- a/api_gateway/app/static/index.html
+++ b/api_gateway/app/static/index.html
@@ -7,6 +7,13 @@
 <body>
     <h1>Robot Services</h1>
     <ul id="services">Loading...</ul>
+
+    <h2>Market Data</h2>
+    <button onclick="loadCandles()">Load Candles</button>
+    <pre id="candles"></pre>
+
+    <h2>Trade Executor</h2>
+    <label>Active: <input type="checkbox" id="toggle" onchange="setActive()"></label>
     <script>
         fetch('/services')
             .then(r => r.json())
@@ -22,6 +29,23 @@
             .catch(() => {
                 document.getElementById('services').textContent = 'Failed to load';
             });
+
+        function loadCandles() {
+            fetch('http://market_data:8000/candles')
+                .then(r => r.json())
+                .then(data => {
+                    document.getElementById('candles').textContent = JSON.stringify(data, null, 2);
+                });
+        }
+
+        function setActive() {
+            const active = document.getElementById('toggle').checked;
+            fetch('http://trade_executor:8000/toggle', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({active})
+            });
+        }
     </script>
 </body>
 </html>

--- a/backtester/app/main.py
+++ b/backtester/app/main.py
@@ -1,7 +1,25 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+import httpx
 
 app = FastAPI(title="backtester")
+
+class BacktestRequest(BaseModel):
+    symbol: str = "BTCUSDT"
+    interval: str = "1m"
+    limit: int = 10
 
 @app.get("/")
 async def root():
     return {"message": "backtester"}
+
+@app.post("/run")
+async def run_backtest(req: BacktestRequest):
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            "http://market_data:8000/candles",
+            params={"symbol": req.symbol, "interval": req.interval, "limit": req.limit},
+        )
+        candles = r.json().get("candles", [])
+    # extremely simplified backtest: just return candles count
+    return {"candles_used": len(candles)}

--- a/backtester/requirements.txt
+++ b/backtester/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+httpx

--- a/indicator_engine/app/main.py
+++ b/indicator_engine/app/main.py
@@ -1,7 +1,20 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
 
 app = FastAPI(title="indicator_engine")
+
+class MARequest(BaseModel):
+    prices: List[float]
+    period: int
 
 @app.get("/")
 async def root():
     return {"message": "indicator_engine"}
+
+@app.post("/ma")
+async def moving_average(req: MARequest):
+    if req.period <= 0 or req.period > len(req.prices):
+        return {"error": "invalid period"}
+    avg = sum(req.prices[-req.period:]) / req.period
+    return {"ma": avg}

--- a/market_data/app/bybit_connector.py
+++ b/market_data/app/bybit_connector.py
@@ -1,0 +1,22 @@
+from typing import List, Dict
+
+class BybitConnector:
+    """Mocked connector to the Bybit API."""
+
+    def __init__(self):
+        self.connected = True
+
+    async def get_latest_candles(self, symbol: str, interval: str = "1m", limit: int = 10) -> List[Dict]:
+        """Return mocked OHLCV candles."""
+        return [
+            {
+                "symbol": symbol,
+                "interval": interval,
+                "open": 1 + i * 0.1,
+                "high": 1.1 + i * 0.1,
+                "low": 0.9 + i * 0.1,
+                "close": 1 + i * 0.1,
+                "volume": 100 + i,
+            }
+            for i in range(limit)
+        ]

--- a/market_data/app/main.py
+++ b/market_data/app/main.py
@@ -1,7 +1,14 @@
 from fastapi import FastAPI
+from .bybit_connector import BybitConnector
 
 app = FastAPI(title="market_data")
+connector = BybitConnector()
 
 @app.get("/")
 async def root():
     return {"message": "market_data"}
+
+@app.get("/candles")
+async def get_candles(symbol: str = "BTCUSDT", interval: str = "1m", limit: int = 10):
+    data = await connector.get_latest_candles(symbol, interval, limit)
+    return {"candles": data}

--- a/strategy_engine/app/main.py
+++ b/strategy_engine/app/main.py
@@ -1,7 +1,32 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Dict, List
 
 app = FastAPI(title="strategy_engine")
+
+# simple in-memory store
+strategies: Dict[str, Dict] = {}
+
+class IndicatorWeight(BaseModel):
+    name: str
+    weight: float
+
+class Strategy(BaseModel):
+    name: str
+    indicators: List[IndicatorWeight]
 
 @app.get("/")
 async def root():
     return {"message": "strategy_engine"}
+
+@app.post("/strategy")
+async def create_strategy(strategy: Strategy):
+    strategies[strategy.name] = strategy.dict()
+    return {"status": "created", "strategy": strategy}
+
+@app.get("/strategy/{name}")
+async def get_strategy(name: str):
+    s = strategies.get(name)
+    if not s:
+        return {"error": "not found"}
+    return s

--- a/trade_executor/app/main.py
+++ b/trade_executor/app/main.py
@@ -1,7 +1,29 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
 
 app = FastAPI(title="trade_executor")
+
+# simple in-memory toggle
+active_trading = False
+
+class Order(BaseModel):
+    symbol: str
+    side: str  # buy or sell
+    qty: float
 
 @app.get("/")
 async def root():
     return {"message": "trade_executor"}
+
+@app.post("/toggle")
+async def toggle(active: bool):
+    global active_trading
+    active_trading = active
+    return {"active": active_trading}
+
+@app.post("/order")
+async def place_order(order: Order):
+    if not active_trading:
+        return {"status": "inactive"}
+    # Mock placing order
+    return {"status": "placed", "order": order}


### PR DESCRIPTION
## Summary
- add a design document describing the microservices
- implement mock Bybit connector and candles endpoint
- support indicator calculation and strategy storage
- add trade executor toggle and order endpoint
- add minimal backtester and update UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6852aa0fa648832ba503c3bb54e0fe5e