### PR TITLE
Add RSI indicator endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ This repository implements a small example of the trading robot described in the
 
 ## Services
 - **api-gateway** – exposes the UI and provides a central entry point to other services
-- **indicator-engine** – calculates trading indicators (e.g. moving average)
+- **indicator-engine** – calculates trading indicators (e.g. moving average and RSI)
 - **strategy-engine** – stores simple strategies composed of weighted indicators
 - **trade-executor** – mock order execution with an on/off toggle
 - **market-data** – provides mocked market data using a Bybit connector
 - **backtester** – runs a very basic backtest using market data
+
+### Indicator Engine Endpoints
+
+- `POST /ma` – calculate a simple moving average.
+- `POST /rsi` – calculate the relative strength index.
 
 ## Running with Docker Compose
 

--- a/TRADING_ROBOT_PROMPT.md
+++ b/TRADING_ROBOT_PROMPT.md
@@ -7,7 +7,7 @@ The platform is split into separate services which communicate over HTTP. Every 
 
 ### Services
 1. **api-gateway** – serves the web UI and proxies requests to the internal services.
-2. **indicator-engine** – calculates indicators such as moving averages.
+2. **indicator-engine** – calculates indicators such as moving averages and RSI.
 3. **strategy-engine** – stores strategies which are defined as a list of indicators and their weights.
 4. **trade-executor** – places orders. The execution can be globally enabled or disabled via the `/toggle` endpoint.
 5. **market-data** – connects to Bybit (mocked) and provides candle data.
@@ -16,7 +16,7 @@ The platform is split into separate services which communicate over HTTP. Every 
 ## Features
 - Web UI available at `/ui` to view service status, fetch market data and enable/disable trading.
 - Toggle external activity (placing orders) via `POST /toggle` on the `trade-executor` service.
-- Calculate indicators through `indicator-engine` (currently only moving average is implemented).
+- Calculate indicators through `indicator-engine` (moving average and RSI are implemented).
 - Create and fetch strategies with `strategy-engine`.
 - Retrieve mocked candles from `market-data`.
 - Run a minimal backtest using `backtester`.

--- a/indicator_engine/app/main.py
+++ b/indicator_engine/app/main.py
@@ -8,6 +8,10 @@ class MARequest(BaseModel):
     prices: List[float]
     period: int
 
+class RSIRequest(BaseModel):
+    prices: List[float]
+    period: int
+
 @app.get("/")
 async def root():
     return {"message": "indicator_engine"}
@@ -18,3 +22,27 @@ async def moving_average(req: MARequest):
         return {"error": "invalid period"}
     avg = sum(req.prices[-req.period:]) / req.period
     return {"ma": avg}
+
+
+@app.post("/rsi")
+async def relative_strength_index(req: RSIRequest):
+    if req.period <= 0 or req.period >= len(req.prices):
+        return {"error": "invalid period"}
+    gains = []
+    losses = []
+    for i in range(1, req.period + 1):
+        diff = req.prices[-(req.period + 1) + i] - req.prices[-(req.period + 1) + i - 1]
+        if diff >= 0:
+            gains.append(diff)
+            losses.append(0)
+        else:
+            gains.append(0)
+            losses.append(-diff)
+    avg_gain = sum(gains) / req.period
+    avg_loss = sum(losses) / req.period
+    if avg_loss == 0:
+        rsi = 100.0
+    else:
+        rs = avg_gain / avg_loss
+        rsi = 100 - (100 / (1 + rs))
+    return {"rsi": rsi}

--- a/tests/test_indicator_engine.py
+++ b/tests/test_indicator_engine.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from indicator_engine.app.main import app
+
+client = TestClient(app)
+
+
+def test_ma():
+    data = {"prices": [1,2,3,4,5], "period": 3}
+    response = client.post("/ma", json=data)
+    assert response.status_code == 200
+    assert response.json() == {"ma": 4.0}
+
+
+def test_rsi():
+    data = {"prices": [1,2,3,2,1,2,3], "period": 3}
+    response = client.post("/rsi", json=data)
+    assert response.status_code == 200
+    assert "rsi" in response.json()


### PR DESCRIPTION
## Summary
- implement relative strength index in `indicator_engine`
- document indicator engine endpoints in README and design doc
- add tests for moving average and RSI endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6852aba1fec8832b9ea765302ed4e7e3