### PR TITLE
Extend services per spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ This repository implements a small example of the trading robot described in the
 
 - `POST /ma` – calculate a simple moving average.
 - `POST /rsi` – calculate the relative strength index.
+- `POST /ema` – calculate the exponential moving average.
+
+### Strategy Engine Endpoints
+
+- `POST /strategy` – create a new strategy.
+- `GET /strategy/{name}` – fetch a strategy by name.
+- `GET /strategies` – list all stored strategies.
 
 ## Running with Docker Compose
 

--- a/indicator_engine/app/main.py
+++ b/indicator_engine/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List
 
+
 app = FastAPI(title="indicator_engine")
 
 class MARequest(BaseModel):
@@ -9,6 +10,10 @@ class MARequest(BaseModel):
     period: int
 
 class RSIRequest(BaseModel):
+    prices: List[float]
+    period: int
+
+class EMARequest(BaseModel):
     prices: List[float]
     period: int
 
@@ -46,3 +51,15 @@ async def relative_strength_index(req: RSIRequest):
         rs = avg_gain / avg_loss
         rsi = 100 - (100 / (1 + rs))
     return {"rsi": rsi}
+
+
+@app.post("/ema")
+async def exponential_moving_average(req: EMARequest):
+    if req.period <= 0 or req.period > len(req.prices):
+        return {"error": "invalid period"}
+    prices = req.prices
+    k = 2 / (req.period + 1)
+    ema = sum(prices[:req.period]) / req.period
+    for price in prices[req.period:]:
+        ema = price * k + ema * (1 - k)
+    return {"ema": ema}

--- a/strategy_engine/app/main.py
+++ b/strategy_engine/app/main.py
@@ -30,3 +30,8 @@ async def get_strategy(name: str):
     if not s:
         return {"error": "not found"}
     return s
+
+
+@app.get("/strategies")
+async def list_strategies():
+    return {"strategies": list(strategies.values())}

--- a/tests/test_indicator_engine.py
+++ b/tests/test_indicator_engine.py
@@ -16,3 +16,10 @@ def test_rsi():
     response = client.post("/rsi", json=data)
     assert response.status_code == 200
     assert "rsi" in response.json()
+
+
+def test_ema():
+    data = {"prices": [1,2,3,4,5,6], "period": 3}
+    response = client.post("/ema", json=data)
+    assert response.status_code == 200
+    assert "ema" in response.json()

--- a/tests/test_strategy_engine.py
+++ b/tests/test_strategy_engine.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from strategy_engine.app.main import app
+
+client = TestClient(app)
+
+
+def test_list_strategies():
+    data = {
+        "name": "test",
+        "indicators": [{"name": "ma", "weight": 1.0}]
+    }
+    client.post("/strategy", json=data)
+    response = client.get("/strategies")
+    assert response.status_code == 200
+    assert response.json()["strategies"]


### PR DESCRIPTION
## Summary
- support exponential moving average in indicator engine
- expose a list of strategies from strategy engine
- document new endpoints in README
- add unit tests for `/ema` and `/strategies`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6852acf28354832ba97957cb46bd2188